### PR TITLE
flowable 表单权限选择联动优化

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/build.gradle
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/build.gradle
@@ -23,6 +23,7 @@ task pack(type: Jar) {
         from 'src/main/webapp'
         exclude 'editor-app/configuration/properties/assignment-display-template.html'
         exclude 'editor-app/configuration/properties/assignment-popup.html'
+        exclude 'editor-app/configuration/properties/form-properties-popup.html'
         exclude 'editor-app/configuration/properties-assignment-controller.js'
         exclude 'editor-app/configuration/properties-form-properties-controller.js'
 


### PR DESCRIPTION
lowable给提供了
require
writable
readable
三个属性设置权限
优先顺序是readable---writable----require
但是在他的表单编辑器并没有将优先顺序表示出来
我们做了联动去解决这个问题