### PR TITLE
解决关闭流程编辑器报错问题

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/editor/oryx.debug.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/editor/oryx.debug.js
@@ -20353,7 +20353,7 @@ ORYX.Plugins.Save = Clazz.extend({
 	},
 	
 	_hasChanges: function() {
-	  return this.changeDifference !== 0 || (this.facade.getModelMetaData()['new'] && this.facade.getCanvas().getChildShapes().size() > 0);
+	  return this.changeDifference !== 0 || (this.facade.getModelMetaData() && this.facade.getModelMetaData()['new'] && this.facade.getCanvas().getChildShapes().size() > 0);
 	},
 	
 	onUnLoad: function(){


### PR DESCRIPTION
修改 点击工作流设计页面X 脚本报错 的bug